### PR TITLE
Explicitly convert a path to a string

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -115,7 +115,7 @@ void MainWindow::openFile()
     std::string text((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     
     // Load the file to GUI
-    this->fileName = std::filesystem::path(fileName.toStdString()).filename();
+    this->fileName = std::filesystem::path(fileName.toStdString()).filename().u8string();
     this->filePath = fileName.toStdString();
     ui->text->clear();
     ui->text->setText(text.c_str());
@@ -153,7 +153,7 @@ void MainWindow::saveFile()
 
     // Change GUI and internal file vars
     this->saved = true;
-    this->fileName = std::filesystem::path(filePath).filename();
+    this->fileName = std::filesystem::path(filePath).filename().u8string();
     this->updateTitle();
 }
 


### PR DESCRIPTION
This fixes compilation on Windows under MSVC.

Tested on 2019 and 2022 as both x86 and x64.